### PR TITLE
Replace binary columns with text

### DIFF
--- a/components/models/src/document.js
+++ b/components/models/src/document.js
@@ -53,7 +53,7 @@ module.exports = function(ot) {
   //, id (auto-incrementing)
   //, createdAt
   //, updatedAt
-   
+
     }
 
     // Class methods
@@ -65,22 +65,22 @@ module.exports = function(ot) {
   function* createWithSnapshot(obj) {
     var ottype = ot.getOTType(obj.type)
     if(!ottype) throw new Error('Specified document type is not available')
-    
+
     var edit = gulf.Edit.newInitial(ottype)
     var contents = ottype.serialize? ottype.serialize(ottype.create()) : ottype.create()
     obj.firstSnapshot = edit.id
     obj.latestSnapshot = edit
     var doc = yield this.create(obj)
-     
+
     var snapshot = {
       id: edit.id
     , document: doc.id
     , changes: JSON.stringify(edit.changeset)
-    , contents: new Buffer(JSON.stringify(contents))
+    , contents: JSON.stringify(contents)
   //, author: not given, since this not a change, but an initial snapshot
     }
     // `create` throws in MySql for example, because the doc creation triggers the creation of an empty snapshot with that id :/
-    yield this.waterline.collections.snapshot.update({id: edit.id}, snapshot) 
+    yield this.waterline.collections.snapshot.update({id: edit.id}, snapshot)
     return doc
   }
 

--- a/components/models/src/snapshot.js
+++ b/components/models/src/snapshot.js
@@ -29,7 +29,7 @@ module.exports = {
     }
 
     // the changeset
-  , changes: 'binary'
+  , changes: 'text'
 
     // the content resulting from the changes
   , contents: 'text'

--- a/components/models/src/snapshot.js
+++ b/components/models/src/snapshot.js
@@ -32,7 +32,7 @@ module.exports = {
   , changes: 'binary'
 
     // the content resulting from the changes
-  , contents: 'binary'
+  , contents: 'text'
 
     // belongsTo a document
   , document: {
@@ -43,7 +43,7 @@ module.exports = {
   , author: {
       model: 'user'
     }
-  
+
   , parent: {
       model: 'snapshot'
     }

--- a/components/models/src/snapshot.js
+++ b/components/models/src/snapshot.js
@@ -9,7 +9,7 @@
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU General Public License for more details.te
  *
  * You should have received a copy of the Mozilla Public License
  * along with this program.  If not, see <https://www.mozilla.org/en-US/MPL/2.0/>.
@@ -29,10 +29,10 @@ module.exports = {
     }
 
     // the changeset
-  , changes: 'text'
+  , changes: 'mediumtext'
 
     // the content resulting from the changes
-  , contents: 'text'
+  , contents: 'mediumtext'
 
     // belongsTo a document
   , document: {

--- a/components/sync/lib/waterline-adapter.js
+++ b/components/sync/lib/waterline-adapter.js
@@ -80,7 +80,7 @@ Adapter.prototype.storeSnapshot = function(docId, snapshot, cb) {
   this.Snapshot.create({
     changes: snapshot.changes
   , parent: snapshot.parent
-  , contents: new Buffer(JSON.stringify(snapshot.contents))
+  , contents: JSON.stringify(snapshot.contents)
   , id: snapshot.id
   , document: docId
   , author: snapshot.author


### PR DESCRIPTION
## Why?
Binary columns imposes some unwanted restrictions. Using text will make hive compatible to a wider range of databases and versions. When you are using a more efficient database like Postgres, it makes no difference of varchar and text anyway.

Mysql might experience a performance drawback when creating temporary tables but it's not applicable to our use case. Neither from my understanding, do we need to be able to index these columns.

## Affected columns
- `contents`
- `changes`

## Developer notes
How do I test this @marcelklehr? I can't see any test suite so I would at least want to do some manul acceptance testing however as my knowledge is somewhat limited working with Node, how would I go about? Is there a way for me to specify in eg. my `package.json` that I would like to use this repository instead of the npm version?

## Other
Related to hivejs/hive-core#1
Closes hivejs/hive#108